### PR TITLE
chore: upgrade golangci-lint to v2 to support Go 1.25

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: setup go
         uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.8
+          version: v2.8.0
       - name: go mod tidy check
         uses: katexochen/go-tidy-check@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,113 +1,114 @@
-run:
-  timeout: 10m
-
-issues:
-  # 显示所有 issue
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  exclude-use-default: false
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    # enable by default
     - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-
-    # custom
     - funlen
-    - gci
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
     - goheader
-    - goimports
     - gosec
+    - govet
+    - ineffassign
     - lll
     - misspell
     - nakedret
     - revive
+    - staticcheck
     - unconvert
     - unparam
-
-linters-settings:
-  # 只开启特定的规则
-  errcheck:
-    exclude-functions:
-      - (*os.File).Close
-      - (io.Closer).Close
-      - (net/http.ResponseWriter).Write
-      - github.com/go-chi/render.Render
-      - io.Copy
-      - os.RemoveAll
-  lll:
-    line-length: 120 # widely used and popular community recommended length
-  funlen:
-    lines: 90 # 函数长度 default * 1.5
-    statements: -1 # 不限制语句数量, 通过圈复杂度处理
-  gocyclo:
-    min-complexity: 30 # 函数圈复杂度
-  govet:
-    check-shadowing: true
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/TencentBlueKing/bscp-go)
-  gocritic:
-    settings:
-      ifElseChain:
-        minThreshold: 3
-  gosec:
-    includes:
-      - G201 # SQL query construction using format string
-      - G202 # SQL query construction using string concatenation
-      - G101 # Look for hard coded credentials
-      - G401 # Detect the usage of DES, RC4, MD5 or SHA1
-      - G402 # Look for bad TLS connection settings
-      - G403 # Ensure minimum RSA key length of 2048 bits
-      - G404 # Insecure random number source (rand)
-      - G504 # Import blocklist: net/http/cgi
-  goheader:
-    values:
-      regexp:
-        YEAR: 20\d\d # 头部时间变量, 如: 2019等, 新增的为当前年份即可
-    template: |-
-      * Tencent is pleased to support the open source community by making Blueking Container Service available.
-       * Copyright (C) {{ YEAR }} THL A29 Limited, a Tencent company. All rights reserved.
-       * Licensed under the MIT License (the "License"); you may not use this file except
-       * in compliance with the License. You may obtain a copy of the License at
-       * http://opensource.org/licenses/MIT
-       * Unless required by applicable law or agreed to in writing, software distributed under
-       * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-       * either express or implied. See the License for the specific language governing permissions and
-       * limitations under the License.
-  misspell:
-    locale: US
-  revive:
-    confidence: 0
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: early-return
-      - name: error-naming
-      - name: error-return
-      - name: error-strings
-      - name: errorf
-      - name: exported
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: var-declaration
-      # - name: var-naming
+    - unused
+  settings:
+    errcheck:
+      exclude-functions:
+        - (*os.File).Close
+        - (io.Closer).Close
+        - (net/http.ResponseWriter).Write
+        - github.com/go-chi/render.Render
+        - io.Copy
+        - os.RemoveAll
+    funlen:
+      lines: 90
+      statements: -1
+    gocritic:
+      settings:
+        ifElseChain:
+          minThreshold: 3
+    gocyclo:
+      min-complexity: 30
+    goheader:
+      values:
+        regexp:
+          YEAR: 20\d\d
+      template: |-
+        * Tencent is pleased to support the open source community by making Blueking Container Service available.
+         * Copyright (C) {{ YEAR }} THL A29 Limited, a Tencent company. All rights reserved.
+         * Licensed under the MIT License (the "License"); you may not use this file except
+         * in compliance with the License. You may obtain a copy of the License at
+         * http://opensource.org/licenses/MIT
+         * Unless required by applicable law or agreed to in writing, software distributed under
+         * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+         * either express or implied. See the License for the specific language governing permissions and
+         * limitations under the License.
+    gosec:
+      includes:
+        - G201
+        - G202
+        - G101
+        - G401
+        - G402
+        - G403
+        - G404
+        - G504
+    lll:
+      line-length: 120
+    misspell:
+      locale: US
+    revive:
+      confidence: 0
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: early-return
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: exported
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: var-declaration
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/TencentBlueKing/bscp-go)
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/client/watch.go
+++ b/client/watch.go
@@ -378,7 +378,9 @@ type subscriber struct {
 }
 
 // CheckConfigItemsChanged check if the subscriber watched config items are changed
+//
 // Deprecated: commit id can not be used to check config items changed anymore
+//
 // ? Should it used in file mode ?
 func (s *subscriber) CheckConfigItemsChanged(cis []*sfs.ConfigItemMetaV1) bool {
 	if len(cis) == 0 {
@@ -398,6 +400,7 @@ func (s *subscriber) CheckConfigItemsChanged(cis []*sfs.ConfigItemMetaV1) bool {
 }
 
 // ResetConfigItems reset the current config items of the subscriber
+//
 // Deprecated: commit id can not be used to check config items changed anymore
 func (s *subscriber) ResetConfigItems(cis []*sfs.ConfigItemMetaV1) {
 	// TODO: Filter by watch options(pattern/regex)

--- a/cmd/bscp/get.go
+++ b/cmd/bscp/get.go
@@ -487,10 +487,7 @@ func runGetKvValues(bscp client.Client, app string, keys []string) error {
 		return err
 	}
 	kvTypeMap := make(map[string]string)
-	isAll := false
-	if len(keys) == 0 {
-		isAll = true
-	}
+	isAll := len(keys) == 0
 	for _, k := range release.KvItems {
 		kvTypeMap[k.Key] = k.KvType
 		if isAll {


### PR DESCRIPTION
升级 CI 中的 golangci-lint 至 v2.8.0（golangci-lint-action@v8），以兼容 go.mod 中更高的 Go 语言版本。

golangci-lint v1.64.x 由 Go 1.24 构建，无法检查目标版本为 Go 1.25 的模块。本次同步迁移 `.golangci.yml` 至 v2，并修复升级后新触发的少量静态检查问题。